### PR TITLE
Remove partial word from Python example

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -650,7 +650,6 @@ The main_booking_token in the response root should be used for booking the fligh
         {"to": "AMS", "flyFrom": "PRG", "directFlights": 0, "dateFrom": "11/06/2017", "dateTo": "28/06/2017"},
         {"to": "OSL", "flyFrom": "AMS", "directFlights": 0, "dateFrom": "01/07/2017", "dateTo": "11/07/2017"}
     ]}
-ligth
 
 ## Group check_flights
 


### PR DESCRIPTION
Cleared up some stray characters in the Python example.